### PR TITLE
B19 save continue updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "api": "json-server-auth -w data/db.json -p 3333 --delay 1500",
+    "api": "json-server-auth -w data/db.json -p 3333",
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",

--- a/src/app.css
+++ b/src/app.css
@@ -150,7 +150,7 @@ button:focus {
 }
 
 button:disabled {
-  opacity: 0.92;
+  opacity: 0.85;
 }
 .modal {
   top: 30%;

--- a/src/app.css
+++ b/src/app.css
@@ -149,6 +149,9 @@ button:focus {
   border: 0.0625px solid var(--gl-orange);
 }
 
+button:disabled {
+  opacity: 0.92;
+}
 .modal {
   top: 30%;
   left: 30%;

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -94,7 +94,8 @@ const Header = () => {
         </svg>
       </div>
       <div className="a11y-btns">
-        <button className="align-right">Skip to main content</button>
+        {/* TODO: Skip to main content button */}
+        {/* <button className="align-right"><a href="#main" className="skip-link">Skip to main content</a></button> */}
         <button
           className="toggle-theme"
           name="toggle-theme"

--- a/src/components/LogInForm/index.tsx
+++ b/src/components/LogInForm/index.tsx
@@ -67,9 +67,10 @@ export const LogInForm = () => {
   const handleSubmit: FormEventHandler<HTMLFormElement> = async (e) => {
     e.preventDefault();
 
+    // TODO: compare emails as lowercase
     try {
       const response = await loginUser({
-        email: formData.email.toLowerCase(),
+        email: formData.email,
         password: formData.password,
       });
       // console.log(response);

--- a/src/components/LogInForm/index.tsx
+++ b/src/components/LogInForm/index.tsx
@@ -84,7 +84,9 @@ export const LogInForm = () => {
         if (!err.response) {
           setErrorMessage("Login failed - No server response");
         } else if (err.response?.status === 400) {
-          setErrorMessage(`Login failed - user does not exist`);
+          setErrorMessage(
+            `Login failed - unknown email or password, please check and try again`
+          );
         } else if (err.response?.status !== 200) {
           setErrorMessage(
             `Status not equal to 200. Status = ${err.response?.status}`

--- a/src/components/LogInPage/index.tsx
+++ b/src/components/LogInPage/index.tsx
@@ -1,15 +1,22 @@
+import { isUndefined } from "lodash";
+import { useState } from "react";
+
 import { useAppSelector } from "../../store";
-import { selectUserFullname } from "../../store/user/selectors";
+import {
+  selectSignUpComplete,
+  selectUserFullname,
+} from "../../store/user/selectors";
 import LogInForm from "../LogInForm";
 
 const LogInPage = () => {
   const userName = useAppSelector(selectUserFullname);
+  const signUpComplete = useAppSelector(selectSignUpComplete);
 
   return (
     <main>
       <LogInForm />
 
-      <h1>Hello {userName ? userName : ""}</h1>
+      <h1>Hello{signUpComplete ? ` ${userName}` : ""}!</h1>
     </main>
   );
 };

--- a/src/components/SignUpPage/PasswordPage/index.tsx
+++ b/src/components/SignUpPage/PasswordPage/index.tsx
@@ -101,6 +101,15 @@ const PasswordPage = ({ id }: { id: string }): React.JSX.Element => {
     const numberTest = numberRegex.test(password);
     const pwdsMatchTest = password === passwordConfirm;
 
+    // User already exists and must have an uncompleted sign up
+    // (otherwise they would have been redirected to log in)
+    // Login user to validate password
+    if (userExists && minCharTest) {
+      testAgainstExistingPassword();
+      return;
+    }
+
+    // Test inputs
     if (
       specialCharTest &&
       minCharTest &&
@@ -162,16 +171,12 @@ const PasswordPage = ({ id }: { id: string }): React.JSX.Element => {
     dispatch(setConfirmPassword(passwordConfirmInputRef.current?.value ?? ""));
 
     // If user doesn't already exist - validate
-    if (!userExists) {
-      validatePassword();
-    } else {
-      // if (userId > -1 && isValid) {/
+    //if (!userExists) {
+    validatePassword();
+    // } else {
 
-      // User already exists and must have an uncompleted sign up
-      // (otherwise they would have been redirected to log in)
-      // Login user to validate password
-      testAgainstExistingPassword();
-    }
+    //   testAgainstExistingPassword();
+    // }
   };
 
   const testAgainstExistingPassword = async () => {
@@ -184,7 +189,9 @@ const PasswordPage = ({ id }: { id: string }): React.JSX.Element => {
       });
 
       dispatch(setValidTrue(id));
-      setErrorMessage("User account retrieved - please continue your sign up");
+      setErrorMessage(
+        "User account retrieved - please Save and Continue to complete your sign up"
+      );
       const jsonUser = JSON.parse(JSON.stringify(response)).user;
       if (userEmail.toLowerCase() !== jsonUser.email) {
         throw Error("Emails do not match");

--- a/src/components/SignUpPage/PasswordPage/index.tsx
+++ b/src/components/SignUpPage/PasswordPage/index.tsx
@@ -170,13 +170,7 @@ const PasswordPage = ({ id }: { id: string }): React.JSX.Element => {
     dispatch(setPassword(passwordInputRef.current?.value ?? ""));
     dispatch(setConfirmPassword(passwordConfirmInputRef.current?.value ?? ""));
 
-    // If user doesn't already exist - validate
-    //if (!userExists) {
     validatePassword();
-    // } else {
-
-    //   testAgainstExistingPassword();
-    // }
   };
 
   const testAgainstExistingPassword = async () => {
@@ -303,9 +297,6 @@ const PasswordPage = ({ id }: { id: string }): React.JSX.Element => {
                   checked={confirmPwdIsVisible}
                   // aria-labelledby="pwdConfirmCheckboxLabel"
                   // aria-checked={confirmPwdIsVisible}
-                  // Confirm password not needed if user has a saved
-                  // but incomplete sign up
-                  // disabled={userId > -1}
                   onChange={() => {
                     setConfirmPwdIsVisible(
                       (confirmPwdIsVisible) => !confirmPwdIsVisible

--- a/src/components/SignUpPage/PasswordPage/index.tsx
+++ b/src/components/SignUpPage/PasswordPage/index.tsx
@@ -190,7 +190,7 @@ const PasswordPage = ({ id }: { id: string }): React.JSX.Element => {
 
       dispatch(setValidTrue(id));
       setErrorMessage(
-        "User account retrieved - please Save and Continue to complete your sign up"
+        "User account retrieved - please Login and Continue to complete your sign up"
       );
       const jsonUser = JSON.parse(JSON.stringify(response)).user;
       if (userEmail.toLowerCase() !== jsonUser.email) {
@@ -351,7 +351,9 @@ const PasswordPage = ({ id }: { id: string }): React.JSX.Element => {
           {/* Permanently show the error/success messages to give user consistent feedback */}
           <ValidationChecklist messageArray={messages} trigger={!userExists} />
 
-          <div className="solo-error-message">
+          <div
+            className={errorMessage !== "" ? "solo-error-message" : "offscreen"}
+          >
             <p ref={errorRef} aria-live="assertive">
               {errorMessage}
             </p>

--- a/src/components/SignUpPage/PasswordPage/index.tsx
+++ b/src/components/SignUpPage/PasswordPage/index.tsx
@@ -204,7 +204,9 @@ const PasswordPage = ({ id }: { id: string }): React.JSX.Element => {
         if (!err.response) {
           setErrorMessage("Login failed - No server response");
         } else if (err.response?.status === 400) {
-          setErrorMessage(`Login failed - incorrect email or password`);
+          setErrorMessage(
+            `Login failed - incorrect email or password, please check and try again`
+          );
         } else if (err.response?.status !== 200) {
           setErrorMessage(
             `Status not equal to 200. Status = ${err.response?.status}`
@@ -349,13 +351,11 @@ const PasswordPage = ({ id }: { id: string }): React.JSX.Element => {
           {/* Permanently show the error/success messages to give user consistent feedback */}
           <ValidationChecklist messageArray={messages} trigger={!userExists} />
 
-          <p
-            ref={errorRef}
-            className={errorMessage ? "errmsg" : "offscreen"}
-            aria-live="assertive"
-          >
-            {errorMessage}
-          </p>
+          <div className="solo-error-message">
+            <p ref={errorRef} aria-live="assertive">
+              {errorMessage}
+            </p>
+          </div>
         </fieldset>
       </form>
     </section>

--- a/src/components/SignUpPage/index.tsx
+++ b/src/components/SignUpPage/index.tsx
@@ -73,6 +73,7 @@ const SignUpPage = (): React.JSX.Element => {
     setErrorMessage("");
     switch (pageRoute) {
       case PageRoutes.SignUpPage:
+        setNextButtonText("Next");
       case PageRoutes.UsernamePage:
         setNextButtonText(userId < 0 ? "Next" : "Log in and continue");
         break;
@@ -290,7 +291,7 @@ const SignUpPage = (): React.JSX.Element => {
           <button
             className="form-button h4-style"
             // Aria-disabled attribute not needed if disabled attribute included
-            disabled={pageNum === 0 || userCreated}
+            disabled={pageNum === 0 || pageNum === 3}
             // No need to add Aria role of 'button' if button has type='button'
             type="button"
             onClick={onPrevious}

--- a/src/components/SignUpPage/index.tsx
+++ b/src/components/SignUpPage/index.tsx
@@ -175,7 +175,6 @@ const SignUpPage = (): React.JSX.Element => {
     if (pageRoute === PageRoutes.PasswordPage && pageIsValid && userId < 0) {
       try {
         const response = await postUser(newUser);
-        //savedUser.email = newUser.email;
         const jsonUser = JSON.parse(JSON.stringify(response)).user;
         console.log(
           `SignUpPage onNext - jsonData = ${JSON.stringify(jsonUser)}`
@@ -214,7 +213,7 @@ const SignUpPage = (): React.JSX.Element => {
       setUserCreated(true);
       setSuccess(true);
     }
-    // For later pages, update user in DB
+    // For later pages, user account will exist - update user in DB
     if (pageRoute === PageRoutes.FullNamePage && pageIsValid) {
       try {
         const response = await updateUser(userId, {

--- a/src/components/SignUpPage/index.tsx
+++ b/src/components/SignUpPage/index.tsx
@@ -44,6 +44,7 @@ const SignUpPage = (): React.JSX.Element => {
     pageNum = 0;
   }
 
+  const [nextButtonText, setNextButtonText] = useState<string>("Next");
   // Store the current page by it's name - so we can control
   // the text on the 'Next' button and what happens when page is complete
   const pageRoute: string = PageRouteArray[pageNum];
@@ -58,7 +59,6 @@ const SignUpPage = (): React.JSX.Element => {
     password: useAppSelector(selectPassword),
   };
 
-  const [nextButtonText, setNextButtonText] = useState<string>("Next");
   // User can 'Save and Continue' once username and password complete
   // The last page should be 'Submit'
   useEffect(() => {
@@ -66,7 +66,7 @@ const SignUpPage = (): React.JSX.Element => {
     switch (pageRoute) {
       case PageRoutes.SignUpPage:
       case PageRoutes.UsernamePage:
-        setNextButtonText("Next");
+        setNextButtonText(userId < 0 ? "Next" : "Login and continue");
         break;
       case PageRoutes.PasswordPage:
         setNextButtonText("Save and Continue");
@@ -84,6 +84,7 @@ const SignUpPage = (): React.JSX.Element => {
     Modal.setAppElement("#root");
   });
 
+  // When Previous button is clicked, return 1 page.
   const onPrevious = () => {
     navigate(-1);
   };

--- a/src/components/SignUpPage/index.tsx
+++ b/src/components/SignUpPage/index.tsx
@@ -66,10 +66,12 @@ const SignUpPage = (): React.JSX.Element => {
     switch (pageRoute) {
       case PageRoutes.SignUpPage:
       case PageRoutes.UsernamePage:
-        setNextButtonText(userId < 0 ? "Next" : "Login and continue");
+        setNextButtonText(userId < 0 ? "Next" : "Log in and continue");
         break;
       case PageRoutes.PasswordPage:
-        setNextButtonText("Save and Continue");
+        setNextButtonText(
+          userId < 0 ? "Save and Continue" : "Log in and continue"
+        );
         break;
       case lastPage: // At present, this is - PageRoutes.FullNamePage:
         setNextButtonText("Submit");
@@ -77,7 +79,7 @@ const SignUpPage = (): React.JSX.Element => {
       default:
         setNextButtonText("Next");
     }
-  }, [pageRoute, lastPage]);
+  }, [pageRoute, lastPage, userId]);
 
   useEffect(() => {
     // Before we draw any modals, bind the modal to the app

--- a/src/components/SignUpPage/index.tsx
+++ b/src/components/SignUpPage/index.tsx
@@ -74,6 +74,7 @@ const SignUpPage = (): React.JSX.Element => {
     switch (pageRoute) {
       case PageRoutes.SignUpPage:
         setNextButtonText("Next");
+        break;
       case PageRoutes.UsernamePage:
         setNextButtonText(userId < 0 ? "Next" : "Log in and continue");
         break;
@@ -278,13 +279,11 @@ const SignUpPage = (): React.JSX.Element => {
           {/* Display inner pages here */}
           <Outlet />
           {/* Error message output */}
-          <p
-            ref={errorRef}
-            className="solo-error-messsage"
-            aria-live="assertive"
-          >
-            {errorMessage}
-          </p>
+          <div className="solo-error-message">
+            <p ref={errorRef} aria-live="assertive">
+              {errorMessage}
+            </p>
+          </div>
         </div>
         {/* Buttons are controlled here, rather than on the individual pages */}
         <div className="button-row">

--- a/src/components/SignUpPage/index.tsx
+++ b/src/components/SignUpPage/index.tsx
@@ -6,6 +6,7 @@ import { Outlet, useLocation, useNavigate } from "react-router-dom";
 import { PageRouteArray, PageRoutes } from "../../router";
 import { getUserByEmail, postUser, updateUser } from "../../services/users";
 import { useAppDispatch, useAppSelector } from "../../store";
+import { resetAll } from "../../store/newUser/newUserSlice";
 import { selectEmail, selectPassword } from "../../store/newUser/selectors";
 import { selectIsValid } from "../../store/signUpPages/selectors";
 import {
@@ -249,8 +250,16 @@ const SignUpPage = (): React.JSX.Element => {
       }
     }
 
-    if (success) {
-      navigate(PageRouteArray[pageNum + 1]);
+    // Clear up and navigate to next page.
+    if (success && pageRoute !== lastPage) {
+      if (pageRoute === PageRoutes.PasswordPage) {
+        // Clear email and password from redux before we navigate away
+        dispatch(resetAll());
+        // Navigate and replace password page with next one
+        navigate(PageRouteArray[pageNum + 1], { replace: true });
+      } else {
+        navigate(PageRouteArray[pageNum + 1]);
+      }
     }
   };
 

--- a/src/components/SignUpPage/index.tsx
+++ b/src/components/SignUpPage/index.tsx
@@ -30,7 +30,7 @@ const SignUpPage = (): React.JSX.Element => {
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
   const [errorMessage, setErrorMessage] = useState("");
-  const [userCreated, setUserCreated] = useState(false);
+  const [, setUserCreated] = useState(false);
   const [success, setSuccess] = useState(false);
   const errorRef = useRef<HTMLParagraphElement>(null);
   const userId = useAppSelector(selectUserId);
@@ -279,7 +279,9 @@ const SignUpPage = (): React.JSX.Element => {
           {/* Display inner pages here */}
           <Outlet />
           {/* Error message output */}
-          <div className="solo-error-message">
+          <div
+            className={errorMessage !== "" ? "solo-error-message" : "offscreen"}
+          >
             <p ref={errorRef} aria-live="assertive">
               {errorMessage}
             </p>

--- a/src/components/SignUpPage/styles.css
+++ b/src/components/SignUpPage/styles.css
@@ -58,17 +58,14 @@ div.checkbox-combo {
   color: var(--primary-color);
   margin: 1em;
 }
-.modal {
-  top: 30%;
-  left: 30%;
+.solo-error-message {
+  margin-left: 0.2em;
+  margin-top: 1em;
   padding: 1em;
-  position: absolute;
-  background-color: var(--primary-color);
-  display: inline-grid;
-  column-count: 2;
-  justify-items: center;
-  border-style: solid;
-  border-color: var(--secondary-color);
+  border: 2px solid var(--gl-orange);
+  /* text-decoration: underline; */
+  /* text-decoration-color: var(--gl-orange); */
+  /* font-weight: bold; */
 }
 /* Moved to app.css */
 /* form {
@@ -97,6 +94,18 @@ div.checkbox-combo {
 .block-input:focus {
   border: 1.5px solid var(--secondary-color);
   width: 60%;
+}
+.modal {
+  top: 30%;
+  left: 30%;
+  padding: 1em;
+  position: absolute;
+  background-color: var(--primary-color);
+  display: inline-grid;
+  column-count: 2;
+  justify-items: center;
+  border-style: solid;
+  border-color: var(--secondary-color);
 }
 */
 /* .success {

--- a/src/components/SignUpPage/styles.css
+++ b/src/components/SignUpPage/styles.css
@@ -63,9 +63,10 @@ div.checkbox-combo {
   margin-top: 1em;
   padding: 1em;
   border: 2px solid var(--gl-orange);
-  /* text-decoration: underline; */
-  /* text-decoration-color: var(--gl-orange); */
-  /* font-weight: bold; */
+}
+
+.offscreen {
+  display: none;
 }
 /* Moved to app.css */
 /* form {

--- a/src/services/users.ts
+++ b/src/services/users.ts
@@ -19,17 +19,21 @@ export const loginUser = async (userData: NewUser) => {
     }
   );
   return data;
-  // } catch (error) {
-  //   if (axios.isAxiosError(error)) {
-  //     //console.log("postUser - error message: ", error.message);
-  //     // return error.message;
-  //     throw new Error(error);
-  //   } else {
-  //     //console.log("postUser - unexpected error: ", error);
-  //     // return "An unexpected error occurred";
-  //     throw "An unexpected error occured";
-  //   }
-  // }
+};
+
+// Update or add specific fields for a user.
+export const updateUser = async (id: number, jsonBody: object) => {
+  const { data } = await axios.patch<string>(
+    `${BASE_URL}/users/${id}`,
+    JSON.stringify(jsonBody),
+    {
+      headers: {
+        "Content-Type": "application/json",
+      },
+    }
+  );
+
+  return data;
 };
 
 // Add a new user to the DB (username and password)
@@ -54,17 +58,6 @@ export const postUser = async (userData: NewUser) => {
   // console.log(JSON.stringify(data, null, 4));
 
   return data; // Should data be returned as raw?
-  // } catch (error) {
-  //   if (axios.isAxiosError(error)) {
-  //     console.log("postUser - error message: ", error.message);
-  //     // return error.message;
-  //     return error.message;
-  //   } else {
-  //     console.log("postUser - unexpected error: ", error);
-  //     // return "An unexpected error occurred";
-  //     return "An unexpected error occured";
-  //   }
-  // }
 };
 
 // Search DB by email to check if user already exists
@@ -76,15 +69,6 @@ export const getUserByEmail = async (email: string) => {
     },
   });
   return data;
-  // } catch (error) {
-  //   if (axios.isAxiosError(error)) {
-  //     console.log("getUserById - error message: ", error.message);
-  //     return error.message;
-  //   } else {
-  //     console.log("getUserById - unexpected error: ", error);
-  //     return "An unexpected error occurred";
-  //   }
-  // }
 };
 
 // Get all users from DB

--- a/src/store/newUser/newUserSlice.ts
+++ b/src/store/newUser/newUserSlice.ts
@@ -30,6 +30,11 @@ const newUserSlice = createSlice({
     resetConfirmPassword(state) {
       state.confirmPassword = "";
     },
+    resetAll(state) {
+      state.email = "";
+      state.password = "";
+      state.confirmPassword = "";
+    },
   },
 });
 
@@ -43,6 +48,7 @@ export const {
   resetPassword,
   setConfirmPassword,
   resetConfirmPassword,
+  resetAll,
 } = newUserSlice.actions;
 
 export default newUserSlice.reducer;


### PR DESCRIPTION
- Decided against below, kept the logic in the passwordPage dialog so that isValid can depend on this test.
           Move testAgainstExistingPassword() to SignUpPage.onNext() method. - signUpPage - if passwordPage && userExists
- passwordPage - test the password once the input in the field passes minimum length test and set isValid = true 
- If user exists - Change text on button to "login and continue"
- SignUpPage - Name page - update user account (all users will have one by this point)
- Disable previous button for pages after password
- Clear or move newUser Redux state to user? once user account saved or retrieved
- On final submit - inform user, redirect to log in and update signUpComplete in DB and redux