### PR TITLE
B20 responsive breadcrumb

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -153,10 +153,11 @@ button:disabled {
   opacity: 0.85;
 }
 .modal {
-  top: 30%;
-  left: 30%;
   padding: 1em;
   position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   background-color: var(--primary-color);
   display: inline-grid;
   column-count: 2;

--- a/src/components/LogInForm/index.tsx
+++ b/src/components/LogInForm/index.tsx
@@ -31,6 +31,8 @@ export const LogInForm = () => {
     email: "",
     password: "",
   });
+  // Toggle password visibility
+  const [pwdIsVisible, setPwdIsVisible] = useState(false);
   // Used to trigger the Modal appearance if user needs to
   // complete the sign up procedure to continue.
   const [redirectModalIsOpen, setRedirectModalIsOpen] = useState(false);
@@ -130,14 +132,37 @@ export const LogInForm = () => {
               value={formData.email}
               required
             />
+
             <label className="help-label" htmlFor="password" id="pwd-label">
               Your password:
             </label>
+            {/* Toggle between password visibility */}
+            <div className="checkbox-combo" id="password-combo">
+              <input
+                id="pwdCheckbox"
+                name="pwdCheckbox"
+                type="checkbox"
+                checked={pwdIsVisible}
+                // aria-labelledby="pwdCheckboxLabel"
+                // aria-checked={pwdIsVisible}
+                onChange={() => {
+                  setPwdIsVisible((pwdIsVisible) => !pwdIsVisible);
+                }}
+              />
+              <label
+                className="checkbox-label"
+                htmlFor="pwdCheckbox"
+                id="pwdCheckboxLabel"
+              >
+                Show password?
+              </label>
+            </div>
+
             <input
               className="block-input"
               id="password"
               name="password"
-              type="password"
+              type={pwdIsVisible ? "text" : "password"}
               autoComplete="password"
               aria-labelledby="pwd-label"
               aria-required="true"

--- a/src/components/LogInPage/index.tsx
+++ b/src/components/LogInPage/index.tsx
@@ -1,6 +1,3 @@
-import { isUndefined } from "lodash";
-import { useState } from "react";
-
 import { useAppSelector } from "../../store";
 import {
   selectSignUpComplete,

--- a/src/components/SignUpPage/FullNamePage/index.tsx
+++ b/src/components/SignUpPage/FullNamePage/index.tsx
@@ -168,7 +168,6 @@ const FullNamePage = ({ id }: { id: string }): React.JSX.Element => {
             </label>
             <input
               className="block-input"
-              autoFocus
               type="text"
               id="family-name"
               ref={familyNameRef}

--- a/src/components/common/BreadcrumbTrail/index.tsx
+++ b/src/components/common/BreadcrumbTrail/index.tsx
@@ -19,6 +19,7 @@ const BreadcrumbTrail = ({
           // if last element - mark as current step for aria,
           // mark all others as false
           aria-current={i === currentStep ? "step" : "false"}
+          id={i === currentStep ? "current-step" : "not-current"}
         >
           <strong>Step {i + 1}</strong>
           <p>{formTitles[i]}</p>
@@ -34,7 +35,7 @@ const BreadcrumbTrail = ({
   }
 
   content.push(
-    <div key="stepsRemaining" className="crumb">
+    <div key="stepsRemaining" className="crumb" id="steps-remaining">
       <strong>Steps Remaining</strong>
       <p>{formTitles.length - currentStep - 1}</p>
     </div>

--- a/src/components/common/BreadcrumbTrail/styles.css
+++ b/src/components/common/BreadcrumbTrail/styles.css
@@ -37,3 +37,20 @@ div.divider {
 .breadcrumb p {
   padding: 0.01rem;
 }
+
+/* Reduce the breadcrumb trail to just the important crumbs */
+@media only screen and (max-width: 900px) {
+  #not-current,
+  div.divider {
+    display: none;
+  }
+
+  #current-step {
+    box-shadow: 0 0 0.05em 0 var(--orange-shadow-rgba);
+  }
+
+  #steps-remaining {
+    /* TODO: remove box shadow, or reduce? */
+    margin-left: 1em;
+  }
+}


### PR DESCRIPTION
- Updated breadcrumb display (CSS?) - hide all but current step and steps remaining for screens below 900 width.
Extra fixes:

- AutoFocus issue on inputs on PasswordPage
- Show password toggle on LoginForm
